### PR TITLE
(fix) Nullable parameter deprecation warnings - v1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# Payable Package - Claude Instructions
+
+## Branch Structure
+
+This package maintains two active versions:
+
+-   **Version 2**: Built from the `main` branch (current development)
+-   **Version 1**: Built from the `v1` branch (legacy support)
+
+## GitHub Issue Resolution
+
+When resolving GitHub issues:
+
+1. **Check the issue context** - Determine if the issue affects:
+
+    - Only v2 (main branch)
+    - Only v1 (v1 branch)
+    - Both versions
+
+2. **For issues affecting both versions:**
+
+    - Create separate branches from each base branch
+    - Apply fixes to both versions
+    - Create separate pull requests for each branch
+    - Ensure compatibility with each version's codebase
+
+3. **Branch naming convention:**
+    - For v2: `feature/issue-{id}-{slug}` from `main`
+    - For v1: `feature/v1-issue-{id}-{slug}` from `v1`
+
+## Development Guidelines
+
+-   Always check which version(s) an issue targets before starting work
+-   Consider backward compatibility when making changes to v1
+-   Test changes in the appropriate version context
+-   Document any version-specific considerations in pull requests

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -30,8 +30,8 @@ class Provider
         PaymentType $paymentType,
         $testPayment = null,
         $api_key = null,
-        callable $extraPaymentDataCallback = null,
-        callable $extraPaymentModifier = null
+        ?callable $extraPaymentDataCallback = null,
+        ?callable $extraPaymentModifier = null
     ): string {
         $this->payableModel = $payableModel;
         $this->paymentType = $paymentType;

--- a/src/Traits/Payable.php
+++ b/src/Traits/Payable.php
@@ -19,8 +19,8 @@ trait Payable
         PaymentType $paymentType,
         $testPayment = null,
         $apiKey = null,
-        callable $extraPaymentDataCallback = null,
-        callable $extraPaymentModifier = null,
+        ?callable $extraPaymentDataCallback = null,
+        ?callable $extraPaymentModifier = null,
         bool $is_recurring = false,
     ) {
         if (!$this->paymentAllowed()) {
@@ -44,8 +44,8 @@ trait Payable
         PaymentType $paymentType,
         $testPayment = null,
         $apiKey = null,
-        callable $extraPaymentDataCallback = null,
-        callable $extraPaymentModifier = null,
+        ?callable $extraPaymentDataCallback = null,
+        ?callable $extraPaymentModifier = null,
     ) {
         return $this->startPayment(
             paymentType: $paymentType,


### PR DESCRIPTION
## Summary
- Fixed PHP 8.0+ deprecation warnings for implicit nullable parameters
- Added explicit `?` to callable parameters with null defaults
- Resolves 124 deprecation warnings mentioned in issue #80

## Changes
- Fixed `startPayment()` method in Payable trait 
- Fixed `startRecurringPayment()` method in Payable trait
- Fixed `preparePayment()` method in Provider class

## Before
```php
callable $extraPaymentDataCallback = null,
callable $extraPaymentModifier = null,
```

## After  
```php
?callable $extraPaymentDataCallback = null,
?callable $extraPaymentModifier = null,
```

## Test plan
- [x] Verify no syntax errors
- [x] Check that method signatures are consistent
- [ ] Test in PHP 8.0+ environment to confirm warnings are resolved

Resolves #80 (v1 branch)