### PR TITLE
(fix) Handle MultiSafePay 'shipped' status

### DIFF
--- a/src/Providers/MultiSafePay.php
+++ b/src/Providers/MultiSafePay.php
@@ -125,9 +125,6 @@ class MultiSafePay extends Provider implements PaymentProviderContract
 
     public function convertStatus($status): string
     {
-        /**
-         * TO DO: handle status `shipped`.
-         */
         switch ($status) {
             case 'initialized':
             case 'void':
@@ -156,6 +153,11 @@ class MultiSafePay extends Provider implements PaymentProviderContract
             case 'partial_refunded':
             case 'chargeback':
                 return Payment::STATUS_REFUNDED;
+                break;
+
+            case 'shipped':
+                // Goods have been shipped and payment is being finalized
+                return Payment::STATUS_COMPLETED;
                 break;
 
             default:


### PR DESCRIPTION
## Problem

MultiSafePay sends a 'shipped' status for Buy Now Pay Later payment methods when goods have been delivered to customers. This status was not handled in the `convertStatus` method, causing an 'Unknown payment status shipped' exception.

This issue affected production with:
- 4,756 error occurrences
- 29 users impacted

## Solution

Added handling for the 'shipped' status in the `MultiSafePay::convertStatus()` method, mapping it to `Payment::STATUS_COMPLETED` since it indicates goods have been delivered and payment processing is being finalized.

## Changes

- Added 'shipped' case to the switch statement in `convertStatus()`
- Removed the TODO comment that mentioned this status needed handling
- Maps 'shipped' status to `Payment::STATUS_COMPLETED`

## Testing

The fix has been tested and resolves the exception while maintaining backward compatibility with all existing status mappings.

## Documentation Reference

According to MultiSafePay documentation, the 'shipped' status is used with BNPL methods to trigger customer billing after goods are delivered.